### PR TITLE
API 요청 횟수 제한

### DIFF
--- a/src/main/java/com/shop/cafe/StockBackendApplication.java
+++ b/src/main/java/com/shop/cafe/StockBackendApplication.java
@@ -1,6 +1,5 @@
 package com.shop.cafe;
 
-
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/shop/cafe/dao/UserMapper.java
+++ b/src/main/java/com/shop/cafe/dao/UserMapper.java
@@ -2,8 +2,6 @@ package com.shop.cafe.dao;
 
 import com.shop.cafe.dto.User;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface UserMapper {

--- a/src/main/java/com/shop/cafe/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/com/shop/cafe/interceptor/RateLimitInterceptor.java
@@ -2,6 +2,9 @@ package com.shop.cafe.interceptor;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -11,15 +14,34 @@ import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 public class RateLimitInterceptor implements HandlerInterceptor {
-	private static final int MAX_REQUESTS = 10;  // 허용 요청 횟수
-    private static final int TIME_WINDOW = 5;   // 제한 시간(초)
+	// 5초 동안 10회 허용
+	private static final int MAX_REQUESTS = 10;  
+    private static final int TIME_WINDOW = 5;   
     
 	private final Map<String, Integer> requestCounts = new ConcurrentHashMap<>();
+	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+	
+	public RateLimitInterceptor() {
+        // TIME_WINDOW(초)마다 요청 카운트 기록 초기화
+        scheduler.scheduleAtFixedRate(requestCounts::clear, TIME_WINDOW, TIME_WINDOW, TimeUnit.SECONDS);
+    }
 	 
 	@Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        
-        System.out.println("Hi, I'm interceptor.");
+		String clientIP = request.getRemoteAddr();
+		
+		requestCounts.putIfAbsent(clientIP, 0); // 초기화
+		
+		int currCount = requestCounts.get(clientIP);
+		
+		// 요청 횟수 초과
+		if (currCount >= MAX_REQUESTS) {
+			response.sendError(429, "Blocked. Retry later.");
+			return false;
+		}
+		
+		requestCounts.put(clientIP, currCount + 1);
+		System.out.println("API count: " + (currCount + 1));
         
         return true;
     }  

--- a/src/main/java/com/shop/cafe/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/com/shop/cafe/interceptor/RateLimitInterceptor.java
@@ -1,0 +1,26 @@
+package com.shop.cafe.interceptor;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class RateLimitInterceptor implements HandlerInterceptor {
+	private static final int MAX_REQUESTS = 10;  // 허용 요청 횟수
+    private static final int TIME_WINDOW = 5;   // 제한 시간(초)
+    
+	private final Map<String, Integer> requestCounts = new ConcurrentHashMap<>();
+	 
+	@Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        
+        System.out.println("Hi, I'm interceptor.");
+        
+        return true;
+    }  
+}


### PR DESCRIPTION
## 📌 개요

클라이언트 IP마다 API 요청 횟수를 제한하는 interpretor를 추가했습니다.

## 🔍 주요 변경 사항

- RateLimitInterpretor 추가
- WebConfig에 interpretor 등록

## ✅ 체크리스트

- [x] 관련 문서가 업데이트되었습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경된 파일과 커밋이 올바른지 확인했습니다.
- [x] 중요 정보가 노출되지 않았습니다.
- [x] 리뷰어를 지정했습니다.
