### PR TITLE
auth가 빈 문자열이면 401 반환

### DIFF
--- a/src/main/java/com/shop/cafe/controller/WalletController.java
+++ b/src/main/java/com/shop/cafe/controller/WalletController.java
@@ -21,6 +21,8 @@ public class WalletController {
 
     @GetMapping("")
     public ResponseEntity<?> getWallet(@RequestHeader("Authorization") String authorization)  {
+    	if (authorization.equals("")) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    	
     	Map<String, Object> response = new HashMap<>();
     	
     	try {


### PR DESCRIPTION
## 📌 개요

Authorization이 빈 문자열이면 401 반환

## 🔍 주요 변경 사항

- FE Authorization 설정 시 토큰이 없으면 null이 아닌 빈 문자열 넘겨야 함
- null이면 400 에러 발생

## ✅ 체크리스트

- [x] 관련 문서가 업데이트되었습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경된 파일과 커밋이 올바른지 확인했습니다.
- [x] 중요 정보가 노출되지 않았습니다.
- [x] 리뷰어를 지정했습니다.
